### PR TITLE
chore: rework babel plugin

### DIFF
--- a/babel/transform-to-amd-if-required.js
+++ b/babel/transform-to-amd-if-required.js
@@ -1,0 +1,151 @@
+import template from "babel-template";
+
+let buildDefine = template(`
+  define(MODULE_NAME, [SOURCES], function (PARAMS) {
+    BODY;
+  });
+`);
+
+export default function ({ types: t }) {
+    function isValidRequireCall(path) {
+        if (!path.isCallExpression()) return false;
+        if (!path.get("callee").isIdentifier({ name: "require" })) return false;
+        if (path.scope.getBinding("require")) return false;
+
+        let args = path.get("arguments");
+        if (args.length !== 1) return false;
+
+        let arg = args[0];
+        if (!arg.isStringLiteral()) return false;
+
+        return true;
+    }
+
+    function isValidDefine(path) {
+        if (!path.isExpressionStatement()) return;
+
+        let expr = path.get("expression");
+        if (!expr.isCallExpression()) return false;
+        if (!expr.get("callee").isIdentifier({ name: "define" }) &&
+            !expr.get("callee").isIdentifier({ name: "require" })) return false;
+
+        let args = expr.get("arguments");
+        if (args.length === 3 && !args.shift().isStringLiteral()) return false;
+
+        let firstArg = args.shift();
+        if (firstArg.isArrayExpression()) {
+            let secondArg = args.shift();
+            if (secondArg.isFunctionExpression()) {
+                return true;
+            }
+        } else if (firstArg.isFunctionExpression()) {
+            return true;
+        }
+
+        return false;
+    }
+
+    function isValidRequireConfig(path) {
+        if (!path.isExpressionStatement()) return;
+
+        let expr = path.get("expression");
+        if (!expr.isCallExpression()) return false;
+
+        if (!expr.get("callee").get('object').isIdentifier({ name: "require" }) ||
+            !expr.get("callee").get('property').isIdentifier({ name: "config" })) return false;
+
+        return true;
+    }
+
+    let amdVisitor = {
+        ReferencedIdentifier({ node, scope }) {
+            if (node.name === "exports" && !scope.getBinding("exports")) {
+                this.hasExports = true;
+            }
+
+            if (node.name === "module" && !scope.getBinding("module")) {
+                this.hasModule = true;
+            }
+        },
+
+        CallExpression(path) {
+            if (!isValidRequireCall(path)) return;
+            this.bareSources.push(path.node.arguments[0]);
+            path.remove();
+        },
+
+        VariableDeclarator(path) {
+            let id = path.get("id");
+            if (!id.isIdentifier()) return;
+
+            let init = path.get("init");
+            if (!isValidRequireCall(init)) return;
+
+            let source = init.node.arguments[0];
+            this.sourceNames[source.value] = true;
+            this.sources.push([id.node, source]);
+
+            path.remove();
+        }
+    };
+
+    return {
+        inherits: require("babel-plugin-transform-es2015-modules-commonjs"),
+
+        pre() {
+            // source strings
+            this.sources = [];
+            this.sourceNames = Object.create(null);
+
+            // bare sources
+            this.bareSources = [];
+
+            this.hasExports = false;
+            this.hasModule = false;
+        },
+
+        visitor: {
+            Program: {
+                exit(path, state) {
+                    if (this.ran) return;
+                    this.ran = true;
+
+                    let body = path.get("body")
+                    let last = body[body.length - 1];
+                    for (var i = 0; i < body.length; i++) {
+                        if (isValidDefine(body[i]) || isValidRequireConfig(body[i])) return;
+                    }
+
+                    path.traverse(amdVisitor, this);
+
+                    let params = this.sources.map(source => source[0]);
+                    let sources = this.sources.map(source => source[1]);
+
+                    sources = sources.concat(this.bareSources.filter((str) => {
+                        return !this.sourceNames[str.value];
+                    }));
+
+                    let moduleName = this.getModuleName();
+                    if (moduleName) moduleName = t.stringLiteral(moduleName);
+
+                    if (this.hasExports) {
+                        sources.unshift(t.stringLiteral("exports"));
+                        params.unshift(t.identifier("exports"));
+                    }
+
+                    if (this.hasModule) {
+                        sources.unshift(t.stringLiteral("module"));
+                        params.unshift(t.identifier("module"));
+                    }
+
+                    path.node.body = [buildDefine({
+                        MODULE_NAME: moduleName,
+                        SOURCES: sources,
+                        PARAMS: params,
+                        BODY: path.node.body
+                    })];
+                }
+            }
+        }
+    };
+}

--- a/babel/transform-to-amd-if-required.js
+++ b/babel/transform-to-amd-if-required.js
@@ -1,8 +1,8 @@
-import template from "@babel/template";
+import {smart as template} from "@babel/template";
 import modulesPlugin from '@babel/plugin-transform-modules-commonjs';
 
 
-let buildDefine = template.default(`
+let buildDefine = template(`
   define(%%MODULE_NAME%%, %%SOURCES%%, function (%%PARAMS%%) {
     %%BODY%%;
   });
@@ -107,7 +107,7 @@ export default function ({ types: t }) {
     };
 
     return {
-        inherits: modulesPlugin.default,
+        inherits: modulesPlugin,
 
         pre() {
             // source strings
@@ -138,7 +138,7 @@ export default function ({ types: t }) {
                     let params = this.sources.map(source => source.moduleParam);
                     let dependencies = this.sources.map(source => source.dependency);
                     let interopCalls = this.sources.filter(source => source.identifier !== null).map(({moduleParam, identifier}) => {
-                        return template.default.ast`let ${identifier.name} = _interopRequireDefault(${moduleParam.name});`
+                        return template.ast`let ${identifier.name} = _interopRequireDefault(${moduleParam.name});`
                     });
 
                     dependencies = dependencies.concat(this.bareSources.filter((str) => {

--- a/babel/transform-to-amd-if-required.js
+++ b/babel/transform-to-amd-if-required.js
@@ -1,3 +1,6 @@
+// Reworked from https://github.com/kayneb/babel-plugin-transform-es2015-modules-amd-if-required
+// Licence: https://github.com/kayneb/babel-plugin-transform-es2015-modules-amd-if-required/blob/1ae1939c3db8bb437ba5881c8479f3171694fadb/LICENSE
+
 import {smart as template} from "@babel/template";
 import modulesPlugin from '@babel/plugin-transform-modules-commonjs';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.5",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
         "@babel/preset-env": "^7.28.5",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.5",
         "babel-plugin-transform-es2015-modules-amd-if-required": "^1.0.4",
         "cors": "^2.8.5",
         "express": "^5.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@babel/preset-env": "^7.28.5",
         "@babel/template": "^7.27.2",
         "@babel/traverse": "^7.28.5",
-        "babel-plugin-transform-es2015-modules-amd-if-required": "^1.0.4",
         "cors": "^2.8.5",
         "express": "^5.2.1",
         "http-proxy-middleware": "^3.0.5",
@@ -1864,62 +1863,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/babel-code-frame": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
-      }
-    },
-    "node_modules/babel-messages": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "node_modules/babel-messages/node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-messages/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
@@ -1966,189 +1909,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-plugin-transform-es2015-modules-amd-if-required": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd-if-required/-/babel-plugin-transform-es2015-modules-amd-if-required-1.0.4.tgz",
-      "integrity": "sha512-qytRfhM0hfU0CwFgVgOkqIZTbWY7lzP6XMKqTyyD5KBlOwZp1hX/hSLdtPXNQS3LM3xsDmDXtlZE2VDXzBZnfA==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.4.0",
-        "babel-runtime": "^5.0.0",
-        "babel-template": "^6.3.13"
-      }
-    },
-    "node_modules/babel-plugin-transform-es2015-modules-commonjs": {
-      "version": "6.26.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
-      "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-transform-strict-mode": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-types": "^6.26.0"
-      }
-    },
-    "node_modules/babel-plugin-transform-es2015-modules-commonjs/node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-plugin-transform-es2015-modules-commonjs/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-plugin-transform-strict-mode": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
-      "integrity": "sha512-j3KtSpjyLSJxNoCDrhwiJad8kw0gJ9REGj8/CqL0HeRyLnvUNYV9zcqluL6QJSXh3nfsLEmSLvwRfGzrgR96Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "node_modules/babel-plugin-transform-strict-mode/node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-plugin-transform-strict-mode/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-runtime": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
-      "integrity": "sha512-KpgoA8VE/pMmNCrnEeeXqFG24TIH11Z3ZaimIhJWsin8EbfZy3WzFKUTIan10ZIDgRVvi9EkLbruJElJC9dRlg==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^1.0.0"
-      }
-    },
-    "node_modules/babel-template": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "node_modules/babel-template/node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-template/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-traverse": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-code-frame": "^6.26.0",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "babylon": "^6.18.0",
-        "debug": "^2.6.8",
-        "globals": "^9.18.0",
-        "invariant": "^2.2.2",
-        "lodash": "^4.17.4"
-      }
-    },
-    "node_modules/babel-traverse/node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-traverse/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
-    "node_modules/babel-types": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
-      "license": "MIT",
-      "dependencies": {
-        "babel-runtime": "^6.26.0",
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.4",
-        "to-fast-properties": "^1.0.3"
-      }
-    },
-    "node_modules/babel-types/node_modules/babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
-      "license": "MIT",
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      }
-    },
-    "node_modules/babel-types/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "hasInstallScript": true,
-      "license": "MIT"
-    },
-    "node_modules/babylon": {
-      "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "license": "MIT",
-      "bin": {
-        "babylon": "bin/babylon.js"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -2316,22 +2076,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/chalk": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/clone-response": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
@@ -2384,13 +2128,6 @@
       "engines": {
         "node": ">=6.6.0"
       }
-    },
-    "node_modules/core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.47.0",
@@ -2480,15 +2217,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
       }
     },
     "node_modules/decompress-response": {
@@ -2628,15 +2356,6 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -2949,15 +2668,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2994,18 +2704,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/got?sponsor=1"
-      }
-    },
-    "node_modules/has-ansi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/has-symbols": {
@@ -3157,15 +2855,6 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -3235,12 +2924,6 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
-    "node_modules/js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
-      "license": "MIT"
-    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3258,12 +2941,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
-    },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -3276,18 +2953,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "license": "MIT"
-    },
-    "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
     },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
@@ -3394,12 +3059,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -3657,12 +3316,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "license": "MIT"
-    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -3909,27 +3562,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -3940,15 +3572,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/to-fast-properties": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
   },
   "dependencies": {
     "@babel/core": "^7.28.5",
+    "@babel/plugin-transform-modules-commonjs": "^7.27.1",
     "@babel/preset-env": "^7.28.5",
+    "@babel/template": "^7.27.2",
+    "@babel/traverse": "^7.28.5",
     "babel-plugin-transform-es2015-modules-amd-if-required": "^1.0.4",
     "cors": "^2.8.5",
     "express": "^5.2.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@babel/preset-env": "^7.28.5",
     "@babel/template": "^7.27.2",
     "@babel/traverse": "^7.28.5",
-    "babel-plugin-transform-es2015-modules-amd-if-required": "^1.0.4",
     "cors": "^2.8.5",
     "express": "^5.2.1",
     "http-proxy-middleware": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "Proxy that converts js files with babel",
   "main": "src/server.js",
+  "type": "module",
   "author": "Daniel Kostro <kostro.d@gmail.com>",
   "scripts": {
     "server": "node src/server.js",

--- a/src/addProxies.js
+++ b/src/addProxies.js
@@ -1,11 +1,11 @@
-const { readFileSync, existsSync } = require("fs");
-const { join } = require("path");
-const { createProxyMiddleware } = require("http-proxy-middleware");
+import {existsSync, readFileSync} from "node:fs";
+import {join} from "node:path";
+import {createProxyMiddleware} from "http-proxy-middleware";
 
-function addProxies(app) {
+export default function addProxies(app) {
   let proxies = [];
 
-  let proxyConfigFile = join(__dirname, "proxy.json");
+  let proxyConfigFile = join(import.meta.dirname, "proxy.json");
   if (existsSync(proxyConfigFile)) {
     proxies = JSON.parse(readFileSync(proxyConfigFile, "utf8"));
     for (let proxy of proxies) {
@@ -19,5 +19,3 @@ function addProxies(app) {
     }
   }
 }
-
-module.exports = addProxies;

--- a/src/babel-proxy.js
+++ b/src/babel-proxy.js
@@ -1,12 +1,11 @@
-'use strict';
+import url from 'node:url';
+import fs from 'node:fs';
+import path from 'node:path';
+import babel from '@babel/core';
+import config from './config.js';
 
-const babel = require('@babel/core');
-const url = require('node:url');
-const config = require('./config');
-const fs = require('node:fs');
-const path = require('node:path');
 
-module.exports = function () {
+export default function () {
   return function (req, res, next) {
     if (shouldTransform(req)) {
       if (config.isLocal) {

--- a/src/babel-proxy.js
+++ b/src/babel-proxy.js
@@ -68,7 +68,7 @@ function doBabel(req, res, txt) {
                 },
             ],
         ],
-        plugins: ['babel-plugin-transform-es2015-modules-amd-if-required'],
+        plugins: ['./babel/transform-to-amd-if-required.js'],
         minified: false,
         ast: false,
     });

--- a/src/cacheControl.js
+++ b/src/cacheControl.js
@@ -1,6 +1,4 @@
-'use strict';
-
-module.exports = function(options) {
+export default function(options) {
   return function(req, res, next) {
     const cache = [];
     if (options.browser !== undefined) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,9 +1,9 @@
-'use strict';
+import minimist from 'minimist';
 
-const config = require('minimist')(process.argv.slice(2));
+const config = minimist(process.argv.slice(2));
 
-if (! config.proxyTarget && __dirname.match('/git')) {
-  config.proxyTarget='file://'+__dirname.replace(/(\/git\/).*/,'$1');
+if (! config.proxyTarget && import.meta.dirname.match('/git')) {
+  config.proxyTarget='file://'+import.meta.dirname.replace(/(\/git\/).*/,'$1');
   console.log('Using as home directory: '+config.proxyTarget);
 }
 
@@ -16,5 +16,5 @@ if (parsed.protocol === 'file:') {
   config.path = parsed.pathname;
 }
 
-module.exports = config;
+export default config;
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,17 +1,17 @@
-'use strict';
+import express from 'express';
+import cors from 'cors';
+import {createProxyMiddleware} from 'http-proxy-middleware';
 
-const express = require('express');
-const app = express();
-const cors = require('cors');
-const cacheControl = require('./cacheControl');
-const babelProxy = require('./babel-proxy');
-const { createProxyMiddleware } = require('http-proxy-middleware');
-const config = require('./config');
-const addProxies = require('./addProxies');
+import cacheControl from './cacheControl.js';
+import babelProxy from './babel-proxy.js';
+import config from './config.js';
+import addProxies from './addProxies.js';
+
 const HOUR = 3600;
 const DAY = 24 * HOUR;
 const MONTH = 30 * DAY;
 
+const app = express();
 app.use(cors());
 app.use(
   cacheControl({


### PR DESCRIPTION
- **chore: copy plugin locally**
- **feat: update plugin to use up-to-date babel packages**
- **chore: use ESM**

I updated the plugin `babel-plugin-transform-es2015-modules-amd-if-required` inherited from (`babel-plugin-transform-es2015-modules-commonjs`) to the new one (`@babel/plugin-transform-modules-commonjs`).

Because the output is different, I had to make some adaptations. I intend to add a few test cases in another PR.

Base on this simple example:

```
import 'standalone';
import { ABC } from 'abc';
import xyz from 'xyz';

console.log(ABC, xyz);
```

This is the output the previous plugin was working with:
```
"use strict";

require("standalone");
var _abc = require("abc");
var _xyz = require("xyz");
var _xyz2 = _interopRequireDefault(_xyz);
function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
console.log(_abc.ABC, _xyz2.default);
```


This is the output my new implementation is working with:

```
"use strict";

require("standalone");
var _abc = require("abc");
var _xyz = _interopRequireDefault(require("xyz"));
function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
console.log(_abc.ABC, _xyz.default);
```

The implementation in this PR is working on scipeaks home view.
